### PR TITLE
Allow wb-graphql to be used as lib or run as web site

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,45 @@ N/A at the moment
 > Find out the return value type of your query (refer above), access the docs for the return type, look under "Fields" for all the fields available for fetching on the current object and the data type of the field. Subfields can be fetched through nesting (refer to examples la)
 
 
+## Use wb-graphql as a library
+
+wb-graphql provides ring handlers that can be combined with a ring web service.
+
+Include the following in the your project.clj dependencies:
+
+```clojure
+[wormbase/wb-graphql "0.1.0-SNAPSHOT"]
+[com.datomic/datomic-pro "0.9.5554" :exclusions [joda-time]]
+[com.amazonaws/aws-java-sdk-dynamodb "1.11.6" :exclusions [joda-time]]
+
+```
+
+Create a ring handler with wb-graphql
+
+```clojure
+(ns rest-api.routing
+  (:require
+   [datomic.api :as d]
+   [wb-graphql.handler]))
+
+(def db (d/db datomic-conn))
+
+(defn graphql-routes [request]
+  (let [handler (-> (wb-graphql.handler/create-routes)
+                    (wb-graphql.handler/wrap-app db))]
+    (handler request)))
+```
+
+## Run wb-graphql as a standalone web service
+
+Locate the standlone uberjar, or refer [here to build a standalone uberjar](#Build standalone uberjar).
+
+    jar -jar path/to/standalone-uberjar.jar
+
+Or with appropriate environment variable
+
+    PORT=[Your_Port] WB_DB_URI=[Your_Datomic_URI] jar -jar path/to/standalone-uberjar.jar
+
 ## To contribute
 
 ### Obtain credentials ###
@@ -100,7 +139,25 @@ TODO...
 
 ### Access graphiql from
 
-    http://localhost:[YOUR_PORT_NO]/index.html
+    http://localhost:[YOUR_PORT_NO]
+
+### Build jar
+
+to use as a library
+
+    npm run build    # build static resources
+    lein run    # build graphql schema
+    lein jar    # build jar
+    lein deploy tmp   # deploy to local repository for testing
+
+### Build standalone uberjar
+
+to run as a server
+
+    npm run build    # build static resources
+    lein run    # build graphql schema
+    lein ring uberjar    # build standalone uberjar
+
 
 ### Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Create a ring handler with wb-graphql
 
 ## Run wb-graphql as a standalone web service
 
-Locate the standlone uberjar, or refer [here to build a standalone uberjar](#Build standalone uberjar).
+Locate the standlone uberjar, or refer [here to build a standalone uberjar](#build-standalone-uberjar).
 
     jar -jar path/to/standalone-uberjar.jar
 

--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
-  }
+  },
+  "homepage": "."
 }

--- a/project.clj
+++ b/project.clj
@@ -35,6 +35,7 @@
          :destroy wb-graphql.handler/destroy
          :auto-reload? true
          :host "0.0.0.0"}
+  :repositories [["tmp" "file:///tmp/clojure_jars"]]
   :javac-options ["-target" "1.8" "-source" "1.8"]
   :jvm-opts ["-Xmx6G"
              ;; same GC options as the transactor,

--- a/project.clj
+++ b/project.clj
@@ -15,19 +15,27 @@
                  [graphql-clj "0.2.2" :exclusions [org.clojure/clojure]]
                  [clojure-future-spec "1.9.0-alpha13"]
                  [mount "0.1.11"]
-                 [environ "1.1.0"]
-                 [com.datomic/datomic-pro "0.9.5554"
-                  :exclusions [joda-time]]
-                 [com.amazonaws/aws-java-sdk-dynamodb "1.11.6"
-                  :exclusions [joda-time]]]
+                 [environ "1.1.0"]]
   :main ^:skip-aot wb-graphql.graphql
   :target-path "target/%s"
   :resource-paths ["resources" "build"]
-  :profiles {:uberjar {:aot :all}
-             :dev {; :ring {:stacktrace-middleware prone.middleware/wrap-exceptions}  ; http://localhost:3000/prone/latest
-                   :resource-paths ["resources" "build"]
-                   :dependencies [[prone "1.1.1"]]
-                   :env {:wb-db-uri "datomic:ddb://us-east-1/WS258/wormbase"}}}
+  :profiles
+  {:datomic-free
+   {:dependencies [[com.datomic/datomic-free "0.9.5554"
+                    :exclusions [joda-time]]]}
+
+   :datomic-pro
+   {:dependencies [[com.datomic/datomic-pro "0.9.5554"
+                    :exclusions [joda-time]]
+                   [com.amazonaws/aws-java-sdk-dynamodb "1.11.6"
+                    :exclusions [joda-time]]]}
+
+   :dev [:datomic-pro
+         {; :ring {:stacktrace-middleware prone.middleware/wrap-exceptions}  ; http://localhost:3000/prone/latest
+          :resource-paths ["resources" "build"]
+          :dependencies [[prone "1.1.1"]]
+          :env {:wb-db-uri "datomic:ddb://us-east-1/WS258/wormbase"}}]
+   :uberjar [:datomic-pro {:aot :all}]}
   :plugins [[lein-environ "1.1.0"]
             [lein-ring "0.11.0"]]
   :ring {:handler wb-graphql.handler/app

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-graphql "0.1.0-SNAPSHOT"
+(defproject wormbase/wb-graphql "0.1.0-SNAPSHOT"
   :description "graphql-clj starter project"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
                  [cheshire "5.6.3"]
                  [ring/ring-json "0.4.0" :exclusions [cheshire]] ;; outdated cheshire mess up connection to Datomic
                  [ring-cors "0.1.8"]
+                 [ring-middleware-accept "2.0.3"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [graphql-clj "0.2.2" :exclusions [org.clojure/clojure]]
                  [clojure-future-spec "1.9.0-alpha13"]

--- a/src/App.js
+++ b/src/App.js
@@ -6,16 +6,17 @@ import fetch from 'isomorphic-fetch';
 
 class App extends Component {
   graphQLFetcher(graphQLParams) {
-    var host = window.location.origin;
-    // var host = "http://localhost:3002";
-    return fetch( host + '/graphql', {
+    const urlPath = window.location.pathname;
+    const graphqlPath = (urlPath.replace(/\/index.html$/, "") || "/");
+    console.log(graphqlPath);
+    return fetch(graphqlPath, {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'same-origin',
       body: JSON.stringify(graphQLParams)
     }).then(response => response.json());
   }
-  
+
   render() {
     return (
         <GraphiQL fetcher={this.graphQLFetcher} />

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ class App extends Component {
   graphQLFetcher(graphQLParams) {
     const urlPath = window.location.pathname;
     const graphqlPath = (urlPath.replace(/\/index.html$/, "") || "/");
-    console.log(graphqlPath);
+
     return fetch(graphqlPath, {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },

--- a/src/wb_graphql/graphql.clj
+++ b/src/wb_graphql/graphql.clj
@@ -327,11 +327,12 @@ type Query {
 
 (defn create-executor [db]
   (let [validated-schema (load-validated-schema)
+        starter-resolver-fn (starter-resolver-factory db)
         context nil]
     (fn [query variables]
       (executor/execute context
                         validated-schema
-                        (starter-resolver-factory db)
+                        starter-resolver-fn
                         query
                         variables))))
 

--- a/src/wb_graphql/graphql.clj
+++ b/src/wb_graphql/graphql.clj
@@ -336,6 +336,8 @@ type Query {
                         query
                         variables))))
 
+(def get-executor (memoize create-executor))
+
 (defn merge-schema [& schema-parts]
   (->> (flatten schema-parts)
        (str/join "\n")))

--- a/src/wb_graphql/handler.clj
+++ b/src/wb_graphql/handler.clj
@@ -18,14 +18,14 @@
         (if (= (:content-type request) "application/json")
           (do (println "GET query: " query)
               (response/response
-               ((graphql/create-executor (:db request)) query variables)))
+               ((graphql/get-executor (:db request)) query variables)))
           (response/redirect "/index.html" 301)))
    (POST "/" [schema query variables :as request]
          (println "POST query: " query)
          ;; (println "Post variables: " (json/parse-string variables))
          (response/response
           (try
-            ((graphql/create-executor (:db request)) query (json/parse-string variables))
+            ((graphql/get-executor (:db request)) query (json/parse-string variables))
             (catch Throwable e
               (println e)))))
    (route/resources "/" {:root ""})

--- a/src/wb_graphql/handler.clj
+++ b/src/wb_graphql/handler.clj
@@ -19,7 +19,10 @@
           (do (println "GET query: " query)
               (response/response
                ((graphql/get-executor (:db request)) query variables)))
-          (response/redirect "/index.html" 301)))
+          (response/redirect (-> (:uri request)
+                                 (clojure.string/replace #"\/$" "")
+                                 (str "/index.html"))
+                             301)))
    (POST "/" [schema query variables :as request]
          (println "POST query: " query)
          ;; (println "Post variables: " (json/parse-string variables))

--- a/src/wb_graphql/handler.clj
+++ b/src/wb_graphql/handler.clj
@@ -14,14 +14,13 @@
 
 (defn create-routes [graphql-executor]
   (routes
-   (GET "/" [] "<h1>Hello World</h1>")
-   (GET "/graphql" [schema query variables :as request]
+   (GET "/" [schema query variables :as request]
         (if (= (:content-type request) "application/json")
           (do (println "GET query: " query)
               (response/response
                (graphql-executor query variables)))
           (response/redirect "/index.html" 301)))
-   (POST "/graphql" [schema query variables :as request]
+   (POST "/" [schema query variables :as request]
          (println "POST query: " query)
          ;; (println "Post variables: " (json/parse-string variables))
          (response/response

--- a/src/wb_graphql/handler.clj
+++ b/src/wb_graphql/handler.clj
@@ -1,6 +1,6 @@
 (ns wb-graphql.handler
   (:require [cheshire.core :as json]
-            [compojure.core :refer [GET POST routes]]
+            [compojure.core :refer [GET POST routes context]]
             [compojure.route :as route]
             [datomic.api :as d]
             [mount.core :as mount]
@@ -12,8 +12,9 @@
             [wb-graphql.db :refer [datomic-conn]]
             [wb-graphql.graphql :as graphql]))
 
-(defn create-routes [graphql-executor]
-  (routes
+(defn create-routes [graphql-executor path-prefix]
+  (context
+   (clojure.string/replace path-prefix #"\/$" "") []
    (GET "/" [schema query variables :as request]
         (if (= (:content-type request) "application/json")
           (do (println "GET query: " query)
@@ -39,7 +40,7 @@
   (mount/stop))
 
 (defn app [request]
-  (let [handler (-> (create-routes graphql-executor)
+  (let [handler (-> (create-routes graphql-executor "")
                     (wrap-json-response)
                     (wrap-cors :access-control-allow-origin [#"http://localhost:8080" #"http://.*"]
                                :access-control-allow-methods [:get :put :post :delete])

--- a/src/wb_graphql/handler.clj
+++ b/src/wb_graphql/handler.clj
@@ -16,9 +16,11 @@
   (routes
    (GET "/" [] "<h1>Hello World</h1>")
    (GET "/graphql" [schema query variables :as request]
-        (println "GET query: " query)
-        (response/response
-         (graphql-executor query variables)))
+        (if (= (:content-type request) "application/json")
+          (do (println "GET query: " query)
+              (response/response
+               (graphql-executor query variables)))
+          (response/redirect "/index.html" 301)))
    (POST "/graphql" [schema query variables :as request]
          (println "POST query: " query)
          ;; (println "Post variables: " (json/parse-string variables))


### PR DESCRIPTION
- allow wb-graphql to be use as library
     - create a ring handler, that can be served from any context
     - ensure static resource can be served and js code can run from any path

